### PR TITLE
Configure logear by environment variable

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,26 +8,25 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"strings"
+	"reflect"
+	"strconv"
 )
 
 var (
-	cfg       map[string]interface{}
+	cfg config
 	logFilter *logutils.LevelFilter
 	logLevels = []logutils.LogLevel{"DEBUG", "INFO", "WARN", "ERROR"}
 )
 
 const (
 	logMinLevel = logutils.LogLevel("INFO")
+	envDelimiter = "_"
 )
 
-func parseTomlFile(filename string) {
-	if data, err := ioutil.ReadFile(filename); err != nil {
-		log.Fatal("[ERROR] Can't read config file ", filename, ", error: ", err)
-	} else {
-		if _, err := toml.Decode(string(data), &cfg); err != nil {
-			log.Fatal("[ERROR] Can't parse config file ", filename, ", error: ", err)
-		}
-	}
+type config struct {
+	sectionName	string
+	data		map[string]interface{}
 }
 
 func readConfig() {
@@ -56,7 +55,98 @@ func readConfig() {
 		println("Architecture: " + runtime.GOARCH)
 		os.Exit(0)
 	}
-	parseTomlFile(configFile)
+	cfg.parseTomlFile(configFile)
 	startLogging()
 	log.Printf("%s started with pid %d", versionstring, os.Getpid())
+}
+
+func (c *config) parseTomlFile(filename string) {
+	if data, err := ioutil.ReadFile(filename); err != nil {
+		log.Fatal("[ERROR] Can't read config file ", filename, ", error: ", err)
+	} else {
+		if _, err := toml.Decode(string(data), &c.data); err != nil {
+			log.Fatal("[ERROR] Can't parse config file ", filename, ", error: ", err)
+		}
+	}
+}
+
+func (c *config) getSection(name string) (interface{}, bool) {
+	data, ok := c.data[name];
+	if !ok {
+		log.Printf("[WARNING] Don't found section named: %s", name)
+		return nil, false
+	}
+	data = overrideByEnv(data, strings.ToLower(progname + envDelimiter + name))
+
+	return data, true
+}
+
+func overrideByEnv(originalData interface{}, sectionName string) interface{} {
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, sectionName) {
+			envNameValue := strings.SplitN(env, "=", 2)
+			envNameValue[0] = strings.TrimPrefix(envNameValue[0], sectionName + envDelimiter)
+
+			switch reflect.TypeOf(originalData).Kind()  {
+			case reflect.Map:
+				data := originalData.(map[string]interface{})
+				applyInMap(envNameValue, data)
+				originalData = data
+			case reflect.Slice:
+				data := originalData.([]map[string]interface{})
+				items := strings.SplitN(envNameValue[0], envDelimiter, 2)
+				if index, err := strconv.Atoi(items[0]); err == nil {
+					envNameValue[0] = items[1]
+					lastIndex := len(data) - 1
+					if index > lastIndex {
+						newData := make(map[string]interface{})
+						applyInMap(envNameValue, newData)
+						data = append(data, newData)
+					} else {
+						applyInMap(envNameValue, data[index])
+					}
+				}
+				originalData = data
+			}
+		}
+	}
+	return originalData
+}
+
+func applyInMap(env []string, data map[string]interface{}) {
+	var propName string
+	var index int
+	var isArray bool = false
+
+	items := strings.Split(env[0], envDelimiter)
+	if len(items) > 1 {
+		if i, err := strconv.Atoi(items[len(items)-1]); err == nil {
+			propName = strings.Join(items[:len(items)-1], envDelimiter)
+			index = i
+			isArray = true
+		} else {
+			propName = env[0]
+		}
+	} else {
+		propName = env[0]
+	}
+
+	if _, ok := data[propName]; ok {
+		switch reflect.TypeOf(data[propName]).Kind() {
+		case reflect.String:
+			data[propName] = env[1]
+		case reflect.Slice:
+			lastIndex := len(data[propName].([]interface{})) - 1
+			if index > lastIndex {
+				data[propName] = append(data[propName].([]interface{}), env[1])
+			} else {
+				data[propName].([]interface{})[index] = env[1]
+			}
+		}
+	} else if isArray {
+		data[propName] = append([]interface{}{}, env[1])
+	} else {
+		data[propName] = env[1]
+	}
+
 }

--- a/config.go
+++ b/config.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/BurntSushi/toml"
-	flag "github.com/docker/docker/pkg/mflag"
+	flag "github.com/getgauge/mflag"
 	"github.com/hashicorp/logutils"
 	"io/ioutil"
 	"log"

--- a/log.go
+++ b/log.go
@@ -33,7 +33,7 @@ func logOpen() {
 	if logFile != "" {
 		logFilter.Writer = openFileLog(logFile)
 	} else {
-		if v, ok := cfg["main"]; ok {
+		if v, ok := cfg.getSection("main"); ok {
 			if v, ok := v.(map[string]interface{})["logfile"]; ok {
 				logFilter.Writer = openFileLog(v.(string))
 			}

--- a/main.go
+++ b/main.go
@@ -11,21 +11,21 @@ func init() {
 func main() {
 	bl.InitMessageQueue(1)
 	//Initializing filters
-	if filters, ok := cfg["filter"]; ok {
+	if filters, ok := cfg.getSection("filter"); ok {
 		filters := filters.([]map[string]interface{})
 		for _, filter := range filters {
 			bl.AddFilter(filter)
 		}
 	}
 	//Initializing outputs
-	if outputs, ok := cfg["output"]; ok {
+	if outputs, ok := cfg.getSection("output"); ok {
 		outputs := outputs.([]map[string]interface{})
 		for _, output := range outputs {
 			bl.AddOutput(bl.InitOutput(output))
 		}
 	}
 	//Initializing inputs
-	if inputs, ok := cfg["input"]; ok {
+	if inputs, ok := cfg.getSection("input"); ok {
 		inputs := inputs.([]map[string]interface{})
 		for _, input := range inputs {
 			bl.AddInput(bl.InitInput(input))


### PR DESCRIPTION
You can override config values by environment variables with special names. Variable name must start from service name (logear) and then are introduced config part name, divider is undeline "_"

For example, in config parameter are described as (toml format)
```
[main]
loglevel=["WARN", "INFO"]
```
variable logear_main_loglevel_1=DEBUG will override second element INFO to DEBUG (indexing from 0) 
variabe logear_main_loglevel_1_345=DEBUG will add third element to array

Again example: input list, in config:
```
[[input]]
type = "filetail"
tag = "jsonlog"
filter = "json"
path = [ "/var/log/app/*.log" ]
timestamp_format = "2006-01-02T15:04:05.999999"
 
[[input]]
type = "in_logear_forwarder"
tag = "fromforwarder"
bind = "0.0.0.0:5000"
ssl_cert = "cert.pem"
ssl_key = "key.pem"
salt    = "123456"
timeout = 60
```
variable logear_input_0_type set paramenter type of first database
variable logear_input_1_binf set paramenter bind of second database
variable logear_input__45_type add third element in array with one paramenter type. By this way you can add other subparameters in third element list with index 45